### PR TITLE
Added test for equipment_bonus blocks without 'instant=yes'

### DIFF
--- a/Scripts/checkEquipmentBonus.py
+++ b/Scripts/checkEquipmentBonus.py
@@ -1,0 +1,58 @@
+from os import listdir
+import time
+from openFile import open_file
+
+
+def check_equipment_bonus(path, output_file):
+    t0 = time.time()
+    subpath = path + '\\common\\ideas'
+
+    for filename in listdir(subpath):
+        current_line = 1
+
+        file = open_file(subpath + '\\' + filename)
+        line = file.readline()
+
+        while line:
+            if "equipment_bonus" in line:
+                in_equipment_bonus_scope = True
+                instant_equals_yes_found = False
+                scope_level = 1
+                line = file.readline()
+                current_line += 1
+
+                while in_equipment_bonus_scope & bool(line):
+                    if instant_equals_yes_found == False:
+                        instant_equals_yes_found = check_for_instant_equals_yes(line)
+                    scope_level += change_in_scope_level(line)
+                    if scope_level == 0:
+                        in_equipment_bonus_scope = False
+                        if not instant_equals_yes_found:
+                            output_file.write("\'instant = yes\' missing from equipment_bonus scope ending at " + str(current_line) + ' in ' + filename + '\n')
+                    line = file.readline()
+                    current_line += 1
+            else:
+                line = file.readline()
+                current_line += 1
+
+
+    t0 = time.time() - t0
+    print("Time taken for equipment bonus script: " + (t0*1000).__str__() + " ms")
+
+
+def check_for_instant_equals_yes(line):
+    instant_equals_yes_found = False
+    for string in ['instant = yes', 'instant=yes', 'instant =yes', 'instant= yes']:
+        if string in line:
+            instant_equals_yes_found = True
+    return instant_equals_yes_found
+
+
+def change_in_scope_level(line):
+    change = 0
+    for character in line:
+        if character == '{':
+            change += 1
+        elif character == '}':
+            change += -1
+    return change

--- a/start.py
+++ b/start.py
@@ -15,6 +15,7 @@ from checkForDoubleLocs import check_for_double_locs
 from checkGFX import check_for_missing_gfx
 from checkFocus import check_for_missing_focus
 from checkCores import check_for_missing_cores
+from checkEquipmentBonus import check_equipment_bonus
 
 
 # output file initialisation
@@ -32,6 +33,7 @@ def start(mod_path, hoi4_path):
     check_for_missing_gfx(mod_path, output_file, hoi4_path)
     check_for_missing_focus(mod_path, output_file)
     check_for_missing_cores(mod_path, output_file)
+    check_equipment_bonus(mod_path, output_file)
     t0 = time.time() - t0
     print("Total time taken: " + (t0*1000).__str__() + " ms")
 


### PR DESCRIPTION
Added a function that checks every file in '/common/ideas' for equipment_bonus scopes, and logs which ones end before it finds an 'instant=yes'.